### PR TITLE
Fix issue 10: failure to restart image stream

### DIFF
--- a/vex/aim.py
+++ b/vex/aim.py
@@ -456,6 +456,7 @@ class WSImageThread(WSThread):
                 try:
                     print(f"{self.ws_name} reconnecting")
                     self.ws.connect(self.uri)
+                    self.start_stream()
                 except:
                     pass # we'll keep trying to reconnect
             else:


### PR DESCRIPTION
In aim.py, if the image stream connection is lost and then restarted via `self.ws.connect(self.uri)` in WSImageThread's run() method, new images do not start arriving automatically. We must do `self.start_stream()` to restore operation. This pull request adds the missing line.